### PR TITLE
Fixes pgoapi.exceptions

### DIFF
--- a/main.js
+++ b/main.js
@@ -219,9 +219,6 @@ function startPython(auth, code, location, opts) {
     logData('python ' + cmdLine.join(' '));
 
     var pythonCmd = 'python';
-    if (os.platform() == 'win32') {
-      pythonCmd = path.join(__dirname, 'pywin', 'python.exe');
-    }
 
     var serverCmdLine = [
       'serveit.py',


### PR DESCRIPTION
This fix the "ImportError: No module named pgoapi.exceptions" error on Windows, since is calling python from the pywin folder, ignoring if the user has already python installed and all dependencies on the main python installation.
