### PR TITLE
Fix `Permission denied` when npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.1-alpha",
   "main": "main.js",
   "scripts": {
-    "postinstall": "cd ./gofbot/ && pip install -r requirements.txt",
+    "postinstall": "cd ./gofbot/ && sudo pip install -r requirements.txt",
     "start": "electron main.js"
   },
   "dependencies": {


### PR DESCRIPTION
### Expected Behavior

npm install success
### Actual Behavior

Got error
### Steps to Reproduce

```
cd ./gofbot/ && pip install -r requirements.txt
```
### Information
- OS: OSX
- App's logs:

```
Exception:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/pip/basecommand.py", line 215, in main
    status = self.run(options, args)
  File "/usr/local/lib/python2.7/site-packages/pip/commands/install.py", line 317, in run
    prefix=options.prefix_path,
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_set.py", line 736, in install
    requirement.uninstall(auto_confirm=True)
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_install.py", line 742, in uninstall
    paths_to_remove.remove(auto_confirm)
  File "/usr/local/lib/python2.7/site-packages/pip/req/req_uninstall.py", line 115, in remove
    renames(path, new_path)
  File "/usr/local/lib/python2.7/site-packages/pip/utils/__init__.py", line 267, in renames
    shutil.move(old, new)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 300, in move
    rmtree(src)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 247, in rmtree
    rmtree(fullname, ignore_errors, onerror)
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 252, in rmtree
    onerror(os.remove, fullname, sys.exc_info())
  File "/usr/local/Cellar/python/2.7.12/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shutil.py", line 250, in rmtree
    os.remove(fullname)
OSError: [Errno 13] Permission denied: '/Library/Python/2.7/site-packages/requests-2.3.0-py2.7.egg/EGG-INFO/dependency_links.txt'
```

Fix this by:

add sudo before pip install

```
 "postinstall": "cd ./gofbot/ && sudo pip install -r requirements.txt",
```
