### PR TITLE
Encryption file presence feedback

### DIFF
--- a/app/login.html
+++ b/app/login.html
@@ -206,16 +206,25 @@
                                 </div>
                                 <div class="col s6">
                                     <h6>Encrypt File</h6>
-                                    <div class="row">
-                                        <div class="">
-                                            <a onclick="openFile()" class="waves-effect waves-light btn">button</a>
-                                            <p id="file_path"></p>
+                                    <div id="selectEncryptionFileDiv">
+                                        <div class="row">
+                                            <div class="">
+                                                <a onclick="openFile()" class="waves-effect waves-light btn">Select</a>
+                                                <p id="file_path"></p>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <p>
+                                                Choose encrypt file.
+                                            </p>
                                         </div>
                                     </div>
-                                    <div class="row">
-                                        <p>
-                                            Choose encrypt file.
-                                        </p>
+                                    <div id="encryptionFileExistsDiv">
+                                        <div class="row">
+                                            <p>
+                                                Encryption file is present. <span class="green-text">✓</span>
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/app/login.js
+++ b/app/login.js
@@ -9,6 +9,7 @@
     var remote = require('electron').remote;
     var dialog = require('electron').remote.dialog;
     var path = require('path');
+    var os = require('os');
 
     var ptcJar = request.jar();
     var ptcReq = request.defaults({
@@ -47,13 +48,33 @@
         setupValue('google_maps_api', $('#google_maps_api'));
         setupValue('walk_speed', $('#walk_speed'));
         setupValue('last_location', $('#location'));
+
+        checkForEncryptionFile();
     });
+
+    function checkForEncryptionFile() {
+        let platform = os.platform(),
+            fileName = platform == 'win32' ? 'encrypt.dll' : 'encrypt.so';
+        fs.access(path.join(__dirname, '../gofbot/' + fileName), fs.constants.R_OK, (err) => {
+            if (err === null) {
+                //No error, file exists and is readable.
+                $('#selectEncryptionFileDiv').hide();
+                $('#encryptionFileExistsDiv').show();
+            }
+            else {
+                //File doesn't exists, let the user select it.
+                $('#selectEncryptionFileDiv').show();
+                $('#encryptionFileExistsDiv').hide();
+            }
+        });
+    }
 
     function openFile() {
         dialog.showOpenDialog(function(fileNames) {
             fs.copySync((fileNames[0]), path.join(__dirname, '../gofbot/encrypt' + fileNames[0].match(/\.\w+/)[0]));
             var file_end = fileNames[0]
-            document.getElementById('file_path').innerHTML = fileNames[0]
+            document.getElementById('file_path').innerHTML = fileNames[0];
+            checkForEncryptionFile();
         });
     }
 


### PR DESCRIPTION
When the encrypt.\* file isn't present or readable the login menu stays the same:  

![image](https://cloud.githubusercontent.com/assets/3439246/17554557/b14aa070-5f0b-11e6-8295-12b4c01b4be3.png)

But once the user select its file trough the menu (and if it's the correct file for the correct OS), the menu changes to:  

![image](https://cloud.githubusercontent.com/assets/3439246/17554592/e462070a-5f0b-11e6-9a6d-a1178c67e590.png)

Works for all OS.
